### PR TITLE
Prioritize choosing glad over glew

### DIFF
--- a/src/imgui_impl/imgui_impl_opengl3.h
+++ b/src/imgui_impl/imgui_impl_opengl3.h
@@ -65,12 +65,12 @@ IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyDeviceObjects();
 
 // Otherwise try to detect supported Desktop OpenGL loaders..
 #elif defined(__has_include)
-#if __has_include(<GL/glew.h>)
-    #define IMGUI_IMPL_OPENGL_LOADER_GLEW
-#elif __has_include(<glad/glad.h>)
+#if __has_include(<glad/glad.h>)
     #define IMGUI_IMPL_OPENGL_LOADER_GLAD
 #elif __has_include(<glad/gl.h>)
     #define IMGUI_IMPL_OPENGL_LOADER_GLAD2
+#elif __has_include(<GL/glew.h>)
+    #define IMGUI_IMPL_OPENGL_LOADER_GLEW
 #elif __has_include(<GL/gl3w.h>)
     #define IMGUI_IMPL_OPENGL_LOADER_GL3W
 #elif __has_include(<glbinding/glbinding.h>)


### PR DESCRIPTION
I was unable to build the project on Ubuntu 20.04 due to the linker tried to link the target against `glew` while the project is using `glad`. This is happening because of the order of choosing a loader in `src/imgui_impl/imgui_impl_opengl3.h`.
This PR changes the order so that the `glad` library is chosen first.

```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.1 LTS
Release:	20.04
Codename:	focal
```